### PR TITLE
templates(prompt): single-prompt ChatGPT template + docs

### DIFF
--- a/Projects/inneros-manifest-v2.md
+++ b/Projects/inneros-manifest-v2.md
@@ -99,6 +99,18 @@ python3 src/cli/workflow_demo.py . --weekly-review --export-checklist weekly-rev
 | **Permanent** | `Permanent Notes/` | `draft → published` | Summarization, link prediction |
 | **Archive** | `Archive/` | `archived` | Compression, historical analysis |
 
+#### Templates (Obsidian Templater)
+- `knowledge/Templates/fleeting.md` — quick capture with automated rename/move.
+- `knowledge/Templates/permanent.md` — structured permanent notes.
+- `knowledge/Templates/literature.md` — literature/reference notes.
+- `knowledge/Templates/daily.md`, `weekly-review.md`, `sprint-review.md`, `sprint-retro.md` — rituals.
+- `knowledge/Templates/chatgpt-prompt.md` — Single-prompt ChatGPT prompt note generator.
+
+Usage:
+- Requires Obsidian Templater. EJS syntax is used (e.g., `<% tp.date.now("YYYY-MM-DD HH:mm") %>`).
+- Prompts once for a feature/branch name, then renames file to `Inbox/prompt-YYYYMMDD-HHmm.md`.
+- Starts with `type: fleeting`, `status: inbox`; tags include `prompt, chatgpt, inbox`.
+
 ### **YAML Schema (Required)**
 ```yaml
 type: permanent | fleeting | literature | MOC

--- a/README.md
+++ b/README.md
@@ -58,7 +58,18 @@ visibility: private | shared | team
     - Permanent notes → `Permanent Notes/`
     - Reference/actionable notes → appropriate folder
 - Only notes with `status: inbox` in YAML are considered active for triage, regardless of folder.
-- The `fleeting.md` template (and others) now include workflow guidance comments to reinforce this process.
+  - The `fleeting.md` template (and others) now include workflow guidance comments to reinforce this process.
+
+## Templates: ChatGPT Prompt (Templater)
+- File: `knowledge/Templates/chatgpt-prompt.md`
+- Purpose: Quickly scaffold a high-quality ChatGPT prompt for a fresh session.
+- How it works:
+  - Uses Obsidian Templater (EJS) tokens like `<% tp.date.now("YYYY-MM-DD HH:mm") %>`
+  - Prompts once for a feature/branch name (single prompt)
+  - Renames and moves the file to `Inbox/prompt-YYYYMMDD-HHmm.md`
+  - YAML includes `type: fleeting`, `status: inbox` and tags `[prompt, chatgpt, inbox]`
+- When to use:
+  - Before starting a new coding/chat iteration to set scope and acceptance criteria
 
 ## 🤖 AI & Automation
 

--- a/knowledge/Templates/chatgpt-prompt.md
+++ b/knowledge/Templates/chatgpt-prompt.md
@@ -1,0 +1,64 @@
+---
+type: fleeting
+created: <% tp.date.now("YYYY-MM-DD HH:mm") %>
+status: inbox
+tags: [prompt, chatgpt, inbox]
+visibility: private
+---
+<%*
+/*------------------------------------------------------------------
+  ChatGPT Prompt Template — Interactive Setup (fleeting pattern)
+  1) Gather context via prompts
+  2) Build file name and path
+  3) Rename & move to Inbox/
+------------------------------------------------------------------*/
+// One-time execution guard to avoid double-run after rename/move
+if (tp.file.title && tp.file.title.startsWith("prompt-")) {
+  tR += "\n<!-- already processed -->\n";
+  return;
+}
+
+// Single-question mode to minimize interaction
+
+const feature = await tp.system.prompt("Feature / branch name?");
+if (!feature) {
+  await tp.system.alert("Cancelled – feature/branch is required.");
+  return;
+}
+const brief = "";
+const rules = "";
+const blocker = "";
+const prev = "";
+const current = "";
+const fileRef = "";
+const learnings = "";
+
+/* Filename + path */
+const stamp  = tp.date.now("YYYYMMDD-HHmm");
+const fname  = `prompt-${stamp}.md`;
+const target = `Inbox/${fname}`;
+
+/* Rename & move */
+try {
+  await tp.file.rename(fname);
+  await tp.file.move(target);
+} catch (e) {
+  await tp.system.alert("Rename/Move failed – " + e.message);
+  return;
+}
+
+/* Emit body */
+tR += `
+## The prompt
+Let's create a new branch for the next feature: ${feature}.
+
+### P0 — Critical/Unblocker
+- Main Task: {MAIN_P0_TASK}
+- Acceptance Criteria:
+  - {MEASURABLE_OUTCOME_1}
+  - {MEASURABLE_OUTCOME_2}
+
+## Next Action (for this session)
+- [ ] {NEXT_ACTION}
+`;
+%>


### PR DESCRIPTION
Refactors chatgpt-prompt.md to a single-prompt flow matching the working fleeting pattern. Simplifies body to P0 with Acceptance Criteria and Next Action checkbox. Updates README and Manifest to reflect new filename pattern (prompt-YYYYMMDD-HHmm.md) and tags [prompt, chatgpt, inbox]. Excludes Inbox artifacts from commit.