### PR TITLE
feat(#121): unified inneros CLI — 34 entry points → 5 subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,8 +174,8 @@ A wide-sweeping architecture simplification is in progress. **Do not suggest edi
 | #119 | Design 10 target modules for `development/src/ai/` (no code) | Done — see `development/docs/issue-119-module-design.md` |
 | #133 | Eliminate dead-code bloat in `src/ai/` and `src/cli/` before collapsing | **Done (2026-05-15)** — 11 ai + 25 cli + 16 tests deleted, commit `f164745` |
 | #120 | Collapse `development/src/ai/` live files → 10 modules | **Done (2026-05-15)** — Phase 1 (8 modules inlined) + Phase 2 (shims + dead-code delete) complete; commit `b525444` |
-| #121 | Reduce CLI from 34 entry points → 5 commands + subcommands | **Next** — blocked on #120 ✅ |
-| #122 | Same-repo isolation for `development/` (Option A chosen) | Open — blocked on #120, #121 |
+| #121 | Reduce CLI from 34 entry points → 5 commands + subcommands | **Done (2026-05-15)** — `inneros.py` unified entry point; commit `352cafc` |
+| #122 | Same-repo isolation for `development/` (Option A chosen) | **Next** — unblocked |
 
 ### Current src/ai/ State (post #120)
 
@@ -187,9 +187,11 @@ A wide-sweeping architecture simplification is in progress. **Do not suggest edi
 
 All old filenames still importable via shims. Test baseline: **932 passing, 26 pre-existing failures** (all 26 target non-existent CLI files — not caused by #120 work).
 
-### Current src/cli/ State (post #133)
+### Current src/cli/ State (post #121)
 
-8 files: `backup_cli.py`, `fleeting_cli.py`, `weekly_review_cli.py`, `cli_logging.py`, `cli_output_contract.py`, `fleeting_formatter.py`, `weekly_review_formatter.py`, `__pycache__/`
+9 files: `inneros.py` (unified entry point), `backup_cli.py`, `fleeting_cli.py`, `weekly_review_cli.py`, `cli_logging.py`, `cli_output_contract.py`, `fleeting_formatter.py`, `weekly_review_formatter.py`, `__pycache__/`
+
+All Makefile targets use `inneros.py`. Old CLI files are kept as importable modules for backward compat.
 
 ### Blocked Work
 

--- a/Makefile
+++ b/Makefile
@@ -12,25 +12,27 @@ VAULT ?= knowledge
 # USER COMMANDS (daily vault maintenance)
 # ============================================
 
+INNEROS := PYTHONPATH=development python3 development/src/cli/inneros.py
+
 review:
 	@echo "📋 Generating weekly review..."
-	PYTHONPATH=development python3 development/src/cli/weekly_review_cli.py --vault $(VAULT) weekly-review --preview
+	$(INNEROS) --vault $(VAULT) review --preview
 
 fleeting:
 	@echo "📊 Checking fleeting notes health..."
-	PYTHONPATH=development python3 development/src/cli/fleeting_cli.py --vault $(VAULT) fleeting-health
+	$(INNEROS) --vault $(VAULT) fleeting health
 
 backup:
 	@echo "📦 Creating vault backup..."
-	PYTHONPATH=development python3 development/src/cli/backup_cli.py --vault $(VAULT) backup
+	$(INNEROS) --vault $(VAULT) backup
 
 inbox: backup
 	@echo "📥 Processing unprocessed inbox notes..."
-	PYTHONPATH=development python3 -c "from src.ai.batch_inbox_processor import batch_process_unprocessed_inbox; from pathlib import Path; import json, sys; r = batch_process_unprocessed_inbox(Path('$(VAULT)/Inbox')); print(json.dumps(r, indent=2)); sys.exit(1 if r.get('errors', 0) > 0 else 0)"
+	$(INNEROS) --vault $(VAULT) inbox
 
 inbox-safe:
 	@echo "📥 [DRY-RUN] Scanning inbox (no changes will be made)..."
-	PYTHONPATH=development python3 -c "from src.ai.batch_inbox_processor import batch_process_unprocessed_inbox; from pathlib import Path; import json, sys; r = batch_process_unprocessed_inbox(Path('$(VAULT)/Inbox'), dry_run=True); print(json.dumps(r, indent=2)); sys.exit(1 if r.get('errors', 0) > 0 else 0)"
+	$(INNEROS) --vault $(VAULT) inbox --dry-run
 
 smoke:
 	@echo "🔥 Running usability smoke test..."
@@ -95,4 +97,4 @@ cov: $(VENV)/bin/activate
 test: lint type unit
 
 run:
-	PYTHONPATH=development python3 development/src/cli/weekly_review_cli.py weekly-review
+	$(INNEROS) --vault $(VAULT) review

--- a/development/src/cli/inneros.py
+++ b/development/src/cli/inneros.py
@@ -121,16 +121,12 @@ def _run_backup(args) -> int:
     cli = BackupCLI(vault_path=args.vault)
     subcommand = getattr(args, "subcommand", None)
     if subcommand == "prune":
-        result = cli.prune_backups(
+        return cli.prune_backups(
             keep=args.keep,
             dry_run=args.dry_run,
-            output_format=getattr(args, "format", "text"),
+            output_format=getattr(args, "format", "normal"),
         )
-    else:
-        result = cli.create_backup(
-            output_format=getattr(args, "format", "text"),
-        )
-    return 0 if result.get("status") in ("success", "ok", None) else 1
+    return cli.backup(output_format=getattr(args, "format", "normal"))
 
 
 def _run_fleeting(args) -> int:
@@ -139,16 +135,12 @@ def _run_fleeting(args) -> int:
     cli = FleetingCLI(vault_path=args.vault)
     subcommand = getattr(args, "subcommand", "health")
     if subcommand == "triage":
-        result = cli.fleeting_triage(
-            output_format=getattr(args, "format", "text"),
+        return cli.fleeting_triage(
+            output_format=getattr(args, "format", "normal"),
             quality_threshold=getattr(args, "quality_threshold", 0.6),
             fast=getattr(args, "fast", False),
         )
-    else:
-        result = cli.fleeting_health(
-            output_format=getattr(args, "format", "text"),
-        )
-    return 0 if result.get("status") in ("success", "ok", None) else 1
+    return cli.fleeting_health(output_format=getattr(args, "format", "normal"))
 
 
 def _run_review(args) -> int:
@@ -157,16 +149,11 @@ def _run_review(args) -> int:
     cli = WeeklyReviewCLI(vault_path=args.vault)
     subcommand = getattr(args, "subcommand", None)
     if subcommand == "metrics":
-        result = cli.enhanced_metrics(
-            output_format=getattr(args, "format", "text"),
-        )
-    else:
-        result = cli.weekly_review(
-            output_format=getattr(args, "format", "text"),
-            preview=getattr(args, "preview", False),
-            export_checklist=getattr(args, "export", False),
-        )
-    return 0 if result.get("status") in ("success", "ok", None) else 1
+        return cli.enhanced_metrics(output_format=getattr(args, "format", "normal"))
+    return cli.weekly_review(
+        output_format=getattr(args, "format", "normal"),
+        preview=getattr(args, "preview", False),
+    )
 
 
 def _run_inbox(args) -> int:

--- a/development/src/cli/inneros.py
+++ b/development/src/cli/inneros.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+inneros — unified CLI entry point for the InnerOS Zettelkasten automation system.
+
+Consolidates backup_cli, fleeting_cli, weekly_review_cli into a single entry
+point. Each domain is a top-level subcommand; secondary actions are nested
+subcommands under that domain.
+
+Usage:
+    inneros --vault /path/to/vault backup
+    inneros --vault /path/to/vault backup prune [--keep N] [--dry-run]
+    inneros --vault /path/to/vault fleeting health [--format json]
+    inneros --vault /path/to/vault fleeting triage [--quality-threshold 0.8] [--fast]
+    inneros --vault /path/to/vault review [--preview] [--export] [--format json]
+    inneros --vault /path/to/vault review metrics [--format json]
+    inneros --vault /path/to/vault inbox [--dry-run] [--format json]
+"""
+
+import sys
+import argparse
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.cli.cli_logging import configure_cli_logging
+
+logger = configure_cli_logging("inneros")
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="inneros",
+        description="InnerOS Zettelkasten automation CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--vault", required=True, help="Path to the Obsidian vault")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+
+    subparsers = parser.add_subparsers(dest="command", metavar="command")
+    subparsers.required = True
+
+    _add_backup_subcommand(subparsers)
+    _add_fleeting_subcommand(subparsers)
+    _add_review_subcommand(subparsers)
+    _add_inbox_subcommand(subparsers)
+
+    return parser
+
+
+def _add_backup_subcommand(subparsers):
+    backup = subparsers.add_parser("backup", help="Vault backup operations")
+    backup_sub = backup.add_subparsers(dest="subcommand", metavar="subcommand")
+
+    prune = backup_sub.add_parser("prune", help="Prune old backups")
+    prune.add_argument(
+        "--keep", type=int, default=3, help="Number of backups to keep (default: 3)"
+    )
+    prune.add_argument(
+        "--dry-run", action="store_true", help="Preview without deleting"
+    )
+    prune.add_argument("--format", choices=["text", "json"], default="text")
+
+
+def _add_fleeting_subcommand(subparsers):
+    fleeting = subparsers.add_parser("fleeting", help="Fleeting note operations")
+    fleeting_sub = fleeting.add_subparsers(dest="subcommand", metavar="subcommand")
+    fleeting_sub.required = True
+
+    health = fleeting_sub.add_parser("health", help="Fleeting notes health report")
+    health.add_argument("--format", choices=["text", "json"], default="text")
+    health.add_argument("--export", metavar="FILE", help="Export report to file")
+
+    triage = fleeting_sub.add_parser("triage", help="AI-powered fleeting note triage")
+    triage.add_argument("--quality-threshold", type=float, default=0.6)
+    triage.add_argument(
+        "--fast", action="store_true", help="Skip AI scoring, use heuristics"
+    )
+    triage.add_argument("--format", choices=["text", "json"], default="text")
+
+
+def _add_review_subcommand(subparsers):
+    review = subparsers.add_parser("review", help="Weekly review operations")
+    review_sub = review.add_subparsers(dest="subcommand", metavar="subcommand")
+
+    review.add_argument(
+        "--preview", action="store_true", help="Preview mode (no writes)"
+    )
+    review.add_argument(
+        "--export", action="store_true", help="Export checklist to file"
+    )
+    review.add_argument("--format", choices=["text", "json"], default="text")
+
+    metrics = review_sub.add_parser("metrics", help="Enhanced analytics metrics")
+    metrics.add_argument("--format", choices=["text", "json"], default="text")
+    metrics.add_argument("--export", metavar="FILE", help="Export metrics to file")
+
+
+def _add_inbox_subcommand(subparsers):
+    inbox = subparsers.add_parser("inbox", help="Process unprocessed inbox notes")
+    inbox.add_argument(
+        "--dry-run", action="store_true", help="Scan only, no processing"
+    )
+    inbox.add_argument("--format", choices=["text", "json"], default="text")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch handlers
+# ---------------------------------------------------------------------------
+
+
+def _run_backup(args) -> int:
+    from src.cli.backup_cli import BackupCLI
+
+    cli = BackupCLI(vault_path=args.vault)
+    subcommand = getattr(args, "subcommand", None)
+    if subcommand == "prune":
+        result = cli.prune_backups(
+            keep=args.keep,
+            dry_run=args.dry_run,
+            output_format=getattr(args, "format", "text"),
+        )
+    else:
+        result = cli.create_backup(
+            output_format=getattr(args, "format", "text"),
+        )
+    return 0 if result.get("status") in ("success", "ok", None) else 1
+
+
+def _run_fleeting(args) -> int:
+    from src.cli.fleeting_cli import FleetingCLI
+
+    cli = FleetingCLI(vault_path=args.vault)
+    subcommand = getattr(args, "subcommand", "health")
+    if subcommand == "triage":
+        result = cli.fleeting_triage(
+            output_format=getattr(args, "format", "text"),
+            quality_threshold=getattr(args, "quality_threshold", 0.6),
+            fast=getattr(args, "fast", False),
+        )
+    else:
+        result = cli.fleeting_health(
+            output_format=getattr(args, "format", "text"),
+        )
+    return 0 if result.get("status") in ("success", "ok", None) else 1
+
+
+def _run_review(args) -> int:
+    from src.cli.weekly_review_cli import WeeklyReviewCLI
+
+    cli = WeeklyReviewCLI(vault_path=args.vault)
+    subcommand = getattr(args, "subcommand", None)
+    if subcommand == "metrics":
+        result = cli.enhanced_metrics(
+            output_format=getattr(args, "format", "text"),
+        )
+    else:
+        result = cli.weekly_review(
+            output_format=getattr(args, "format", "text"),
+            preview=getattr(args, "preview", False),
+            export_checklist=getattr(args, "export", False),
+        )
+    return 0 if result.get("status") in ("success", "ok", None) else 1
+
+
+def _run_inbox(args) -> int:
+    from src.ai.batch import batch_process_unprocessed_inbox
+
+    vault = Path(args.vault)
+    inbox_dir = vault / "Inbox"
+    result = batch_process_unprocessed_inbox(inbox_dir, dry_run=args.dry_run)
+    errors = result.get("errors", 0)
+    return 1 if errors and errors > 0 else 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    dispatch = {
+        "backup": _run_backup,
+        "fleeting": _run_fleeting,
+        "review": _run_review,
+        "inbox": _run_inbox,
+    }
+
+    handler = dispatch.get(args.command)
+    if handler is None:
+        parser.print_help()
+        return 1
+
+    return handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/development/tests/unit/test_inneros_cli.py
+++ b/development/tests/unit/test_inneros_cli.py
@@ -1,0 +1,255 @@
+"""
+Spec tests for the unified inneros CLI (#121).
+
+Verifies the public interface of src/cli/inneros.py:
+- Single entry point replaces backup_cli, fleeting_cli, weekly_review_cli
+- Top-level subcommands: backup, fleeting, review, inbox
+- All original subcommand flags preserved
+- Makefile targets continue to work via the new entry point
+"""
+
+import sys
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import argparse
+
+import pytest
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+src_dir = os.path.join(os.path.dirname(os.path.dirname(current_dir)), "src")
+sys.path.insert(0, src_dir)
+
+from cli.inneros import create_parser, main
+
+
+# ---------------------------------------------------------------------------
+# Parser — top-level structure
+# ---------------------------------------------------------------------------
+
+
+class TestInnerosParserStructure:
+    def setup_method(self):
+        self.parser = create_parser()
+
+    def test_parser_importable(self):
+        assert create_parser is not None
+
+    def test_main_callable(self):
+        assert callable(main)
+
+    def test_parser_has_vault_argument(self):
+        args = self.parser.parse_args(["--vault", "/tmp/vault", "backup"])
+        assert args.vault == "/tmp/vault"
+
+    def test_parser_has_verbose_flag(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "--verbose", "backup"])
+        assert args.verbose is True
+
+    def test_parser_accepts_backup_command(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "backup"])
+        assert args.command == "backup"
+
+    def test_parser_accepts_fleeting_command(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "fleeting", "health"])
+        assert args.command == "fleeting"
+
+    def test_parser_accepts_review_command(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "review"])
+        assert args.command == "review"
+
+    def test_parser_accepts_inbox_command(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "inbox"])
+        assert args.command == "inbox"
+
+
+# ---------------------------------------------------------------------------
+# backup subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestBackupSubcommand:
+    def setup_method(self):
+        self.parser = create_parser()
+
+    def test_backup_default_no_subcommand(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "backup"])
+        assert args.command == "backup"
+
+    def test_backup_prune_subcommand(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "backup", "prune"])
+        assert args.subcommand == "prune"
+
+    def test_backup_prune_has_keep_flag(self):
+        args = self.parser.parse_args(
+            ["--vault", "/tmp", "backup", "prune", "--keep", "5"]
+        )
+        assert args.keep == 5
+
+    def test_backup_prune_keep_defaults_to_3(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "backup", "prune"])
+        assert args.keep == 3
+
+    def test_backup_prune_has_dry_run_flag(self):
+        args = self.parser.parse_args(
+            ["--vault", "/tmp", "backup", "prune", "--dry-run"]
+        )
+        assert args.dry_run is True
+
+
+# ---------------------------------------------------------------------------
+# fleeting subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestFleetingSubcommand:
+    def setup_method(self):
+        self.parser = create_parser()
+
+    def test_fleeting_health_subcommand(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "fleeting", "health"])
+        assert args.command == "fleeting"
+        assert args.subcommand == "health"
+
+    def test_fleeting_triage_subcommand(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "fleeting", "triage"])
+        assert args.command == "fleeting"
+        assert args.subcommand == "triage"
+
+    def test_fleeting_health_has_format_flag(self):
+        args = self.parser.parse_args(
+            ["--vault", "/tmp", "fleeting", "health", "--format", "json"]
+        )
+        assert args.format == "json"
+
+    def test_fleeting_triage_has_quality_threshold(self):
+        args = self.parser.parse_args(
+            ["--vault", "/tmp", "fleeting", "triage", "--quality-threshold", "0.8"]
+        )
+        assert args.quality_threshold == pytest.approx(0.8)
+
+    def test_fleeting_triage_has_fast_flag(self):
+        args = self.parser.parse_args(
+            ["--vault", "/tmp", "fleeting", "triage", "--fast"]
+        )
+        assert args.fast is True
+
+
+# ---------------------------------------------------------------------------
+# review subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestReviewSubcommand:
+    def setup_method(self):
+        self.parser = create_parser()
+
+    def test_review_default(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "review"])
+        assert args.command == "review"
+
+    def test_review_has_preview_flag(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "review", "--preview"])
+        assert args.preview is True
+
+    def test_review_metrics_subcommand(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "review", "metrics"])
+        assert args.subcommand == "metrics"
+
+    def test_review_has_format_flag(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "review", "--format", "json"])
+        assert args.format == "json"
+
+    def test_review_export_flag(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "review", "--export"])
+        assert args.export is True
+
+
+# ---------------------------------------------------------------------------
+# inbox subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestInboxSubcommand:
+    def setup_method(self):
+        self.parser = create_parser()
+
+    def test_inbox_default(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "inbox"])
+        assert args.command == "inbox"
+
+    def test_inbox_has_dry_run_flag(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "inbox", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_inbox_dry_run_defaults_false(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "inbox"])
+        assert args.dry_run is False
+
+    def test_inbox_has_format_flag(self):
+        args = self.parser.parse_args(["--vault", "/tmp", "inbox", "--format", "json"])
+        assert args.format == "json"
+
+
+# ---------------------------------------------------------------------------
+# main() dispatch — each command calls the right handler
+# ---------------------------------------------------------------------------
+
+
+class TestMainDispatch:
+    def test_main_backup_dispatches(self, tmp_path):
+        with patch("cli.inneros._run_backup") as mock:
+            main(["--vault", str(tmp_path), "backup"])
+            mock.assert_called_once()
+
+    def test_main_fleeting_health_dispatches(self, tmp_path):
+        with patch("cli.inneros._run_fleeting") as mock:
+            main(["--vault", str(tmp_path), "fleeting", "health"])
+            mock.assert_called_once()
+
+    def test_main_review_dispatches(self, tmp_path):
+        with patch("cli.inneros._run_review") as mock:
+            main(["--vault", str(tmp_path), "review"])
+            mock.assert_called_once()
+
+    def test_main_inbox_dispatches(self, tmp_path):
+        with patch("cli.inneros._run_inbox") as mock:
+            main(["--vault", str(tmp_path), "inbox"])
+            mock.assert_called_once()
+
+    def test_main_returns_int(self, tmp_path):
+        with patch("cli.inneros._run_backup", return_value=0):
+            result = main(["--vault", str(tmp_path), "backup"])
+        assert isinstance(result, int)
+
+    def test_main_backup_exits_0_on_success(self, tmp_path):
+        with patch("cli.inneros._run_backup", return_value=0):
+            result = main(["--vault", str(tmp_path), "backup"])
+        assert result == 0
+
+    def test_main_exits_nonzero_on_error(self, tmp_path):
+        with patch("cli.inneros._run_backup", return_value=1):
+            result = main(["--vault", str(tmp_path), "backup"])
+        assert result != 0
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat shims — old CLIs still importable
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatShims:
+    def test_backup_cli_still_importable(self):
+        from cli.backup_cli import main as backup_main
+
+        assert callable(backup_main)
+
+    def test_fleeting_cli_still_importable(self):
+        from cli.fleeting_cli import main as fleeting_main
+
+        assert callable(fleeting_main)
+
+    def test_weekly_review_cli_still_importable(self):
+        from cli.weekly_review_cli import main as review_main
+
+        assert callable(review_main)


### PR DESCRIPTION
## Summary

- Created `development/src/cli/inneros.py` as a unified entry point replacing 3 separate CLI files and 2 Makefile Python one-liners
- Interface: `inneros --vault VAULT [backup|backup prune|fleeting health|fleeting triage|review|review metrics|inbox]`
- Updated Makefile: all 5 user-facing targets (`review`, `fleeting`, `backup`, `inbox`, `inbox-safe`) now use `$(INNEROS)` variable pointing at `inneros.py`
- 37 spec tests in `tests/unit/test_inneros_cli.py` — all passing
- Fixed dispatch handlers to use actual method names and int return values (commit `912b6b4`)

## Test plan

- [ ] `cd development && python -m pytest tests/unit/test_inneros_cli.py -q` — 37 tests pass
- [ ] `make review VAULT=<path>` invokes `inneros.py review`
- [ ] `make fleeting VAULT=<path>` invokes `inneros.py fleeting health`
- [ ] `make backup VAULT=<path>` invokes `inneros.py backup`
- [ ] `make inbox VAULT=<path>` invokes `inneros.py inbox`
- [ ] `make inbox-safe VAULT=<path>` invokes `inneros.py inbox` with dry-run

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)