### PR TITLE
feat(#114): replace word-count heuristic with LLM triage via Ollama

### DIFF
--- a/development/src/ai/batch.py
+++ b/development/src/ai/batch.py
@@ -2152,11 +2152,13 @@ class WorkflowManager:
         return self.fleeting_analysis_coordinator.generate_fleeting_health_report()
 
     def generate_fleeting_triage_report(
-        self, quality_threshold: Optional[float] = None, fast: bool = False
+        self,
+        quality_threshold: Optional[float] = None,
+        mutate: bool = False,
     ) -> Dict:
-        """Generate AI-powered triage report for fleeting notes with quality assessment."""
+        """Generate LLM-powered triage report for fleeting notes."""
         return self.review_triage_coordinator.generate_fleeting_triage_report(
-            quality_threshold, fast
+            quality_threshold=quality_threshold, mutate=mutate
         )
 
     def promote_fleeting_note(

--- a/development/src/ai/lifecycle.py
+++ b/development/src/ai/lifecycle.py
@@ -29,6 +29,8 @@ import time
 import logging
 from pathlib import Path
 
+from src.ai.llm_client import OllamaClient
+
 
 @dataclass
 class ImportItem:
@@ -2012,6 +2014,21 @@ class FleetingNoteCoordinator:
 
 from src.utils.tags import sanitize_tags
 
+# Prompt used when vault's fleeting-triage-llm-prompt file is absent.
+_DEFAULT_TRIAGE_SYSTEM_PROMPT = """\
+You are a Zettelkasten triage assistant. Evaluate the fleeting note provided \
+and return a JSON object with exactly three keys:
+  "action"     — one of: "promote_to_permanent", "needs_enhancement", "consider_archiving"
+  "reasoning"  — 1–2 sentences explaining your recommendation
+  "confidence" — one of: "high", "medium", "low"
+
+Criteria: clarity of insight, uniqueness, actionability, connection potential.
+Return ONLY valid JSON. No preamble, no markdown fences.\
+"""
+
+# Relative path inside the vault root where the validated prompt may live.
+_VAULT_TRIAGE_PROMPT_PATH = "knowledge/Prompts/fleeting-triage-llm-prompt-20260511.md"
+
 
 class ReviewTriageCoordinator:
     """
@@ -2329,22 +2346,67 @@ class ReviewTriageCoordinator:
             "metadata": metadata,
         }
 
-    def generate_fleeting_triage_report(
-        self, quality_threshold: Optional[float] = None, fast: bool = False
-    ) -> Dict:
+    def _load_triage_system_prompt(self) -> str:
+        """Return the validated triage prompt from the vault, or the built-in default."""
+        vault_root = (
+            self.base_dir.parent
+        )  # base_dir is knowledge/, vault root is one up
+        prompt_path = vault_root / _VAULT_TRIAGE_PROMPT_PATH
+        if prompt_path.exists():
+            try:
+                return prompt_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                pass
+        return _DEFAULT_TRIAGE_SYSTEM_PROMPT
+
+    def _score_note_with_llm(
+        self, note_path: Path, content: str, ollama: OllamaClient, system_prompt: str
+    ) -> Dict[str, Any]:
+        """Call Ollama with the triage prompt and return parsed JSON result.
+
+        Raises ValueError on malformed JSON so the caller surfaces it loudly.
         """
-        Generate AI-powered triage report for fleeting notes with quality assessment.
+        raw = ollama.generate_completion(prompt=content, system_prompt=system_prompt)
+        try:
+            result = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            raise ValueError(
+                f"LLM returned malformed JSON for '{note_path.name}': {raw[:120]!r}"
+            )
+        if "action" not in result or "reasoning" not in result:
+            raise ValueError(
+                f"LLM JSON missing required keys for '{note_path.name}': {result}"
+            )
+        return result
+
+    def generate_fleeting_triage_report(
+        self, quality_threshold: Optional[float] = None, mutate: bool = False
+    ) -> Dict:
+        """Generate LLM-powered triage report for fleeting notes.
 
         Args:
-            quality_threshold: Optional minimum quality threshold (0.0-1.0) for filtering
-            fast: If True, use fast mode to skip external AI calls for speed
+            quality_threshold: Optional minimum quality filter (0.0-1.0).
+            mutate: If True, write triage_recommendation back to note frontmatter.
+                    Default False — read-only (never modifies files).
 
-        Returns:
-            Dict: Triage report with quality assessment and recommendations
+        Raises:
+            RuntimeError: If Ollama is unavailable (no silent fallback).
+            ValueError: If any note returns malformed JSON from the LLM.
         """
+        from src.utils.frontmatter import parse_frontmatter, build_frontmatter
+        from src.utils.io import safe_write
+
         start_time = time.time()
 
-        # Get fleeting notes for processing
+        # Pre-flight: fail loudly if Ollama is down.
+        ollama = OllamaClient()
+        if not ollama.health_check():
+            raise RuntimeError(
+                "Ollama service is not available. "
+                "Run `ollama serve` and ensure your model is pulled, then retry."
+            )
+
+        system_prompt = self._load_triage_system_prompt()
         fleeting_notes = self._find_fleeting_notes()
 
         if not fleeting_notes:
@@ -2356,81 +2418,63 @@ class ReviewTriageCoordinator:
                 "quality_threshold": quality_threshold,
             }
 
-        # Process each note for quality assessment
-        recommendations = []
-        quality_scores = []
+        recommendations: List[Dict] = []
+        action_counts: Dict[str, int] = {"high": 0, "medium": 0, "low": 0}
 
         for note_path in fleeting_notes:
-            try:
-                # Use existing AI infrastructure for processing
-                result = self.workflow_manager.process_inbox_note(note_path, fast=fast)
+            content = note_path.read_text(encoding="utf-8")
+            llm_result = self._score_note_with_llm(
+                note_path, content, ollama, system_prompt
+            )
 
-                quality_score = result.get("quality_score", 0.5)
-                quality_scores.append(quality_score)
+            action = llm_result.get("action", "needs_enhancement")
+            reasoning = llm_result.get("reasoning", "")
+            confidence = llm_result.get("confidence", "medium")
 
-                # Generate recommendation based on quality
-                if quality_score >= 0.7:
-                    action = "Promote to Permanent"
-                    rationale = "High quality content with clear insights and good structure. Ready for promotion."
-                elif quality_score >= 0.4:
-                    action = "Needs Enhancement"
-                    rationale = "Medium quality with potential. Consider adding more detail or connections."
-                else:
-                    action = "Consider Archiving"
-                    rationale = "Low quality content. May need significant work or could be archived."
+            # Map action to a quality tier for distribution tracking.
+            if action == "promote_to_permanent":
+                tier = "high"
+            elif action == "consider_archiving":
+                tier = "low"
+            else:
+                tier = "medium"
+            action_counts[tier] += 1
 
-                # Apply quality threshold filter if specified
-                if quality_threshold is None or quality_score >= quality_threshold:
-                    recommendations.append(
-                        {
-                            "note_path": str(note_path),
-                            "quality_score": quality_score,
-                            "action": action,
-                            "rationale": rationale,
-                            "ai_tags": result.get("ai_tags", []),
-                            "created": result.get("metadata", {}).get(
-                                "created", "Unknown"
-                            ),
-                        }
+            # Write recommendation back to frontmatter only when explicitly requested.
+            if mutate:
+                try:
+                    frontmatter, body = parse_frontmatter(content)
+                    frontmatter["triage_recommendation"] = action
+                    safe_write(note_path, build_frontmatter(frontmatter, body))
+                except Exception as write_err:
+                    logging.getLogger(__name__).warning(
+                        "triage: failed to write frontmatter for %s: %s",
+                        note_path.name,
+                        write_err,
                     )
 
-            except Exception as e:
-                # Handle individual note processing errors gracefully
-                recommendations.append(
-                    {
-                        "note_path": str(note_path),
-                        "quality_score": 0.0,
-                        "action": "Processing Error",
-                        "rationale": f"Error processing note: {str(e)}",
-                        "ai_tags": [],
-                        "created": "Unknown",
-                    }
-                )
+            quality_score = {"high": 0.8, "medium": 0.5, "low": 0.2}[tier]
+            rec = {
+                "note_path": str(note_path),
+                "action": action,
+                "reasoning": reasoning,
+                "confidence": confidence,
+                "tier": tier,
+                "quality_score": quality_score,
+            }
+            if quality_threshold is None or quality_score >= (quality_threshold or 0.0):
+                recommendations.append(rec)
 
-        # Calculate quality distribution
-        quality_distribution = {"high": 0, "medium": 0, "low": 0}
-        for score in quality_scores:
-            if score >= 0.7:
-                quality_distribution["high"] += 1
-            elif score >= 0.4:
-                quality_distribution["medium"] += 1
-            else:
-                quality_distribution["low"] += 1
-
-        # Sort recommendations by quality score (highest first)
-        recommendations.sort(key=lambda x: x["quality_score"], reverse=True)
-
-        processing_time = time.time() - start_time
-        total_processed = len(fleeting_notes)
-        filtered_count = (
-            total_processed - len(recommendations) if quality_threshold else 0
+        filtered_count = len(fleeting_notes) - len(recommendations)
+        recommendations.sort(
+            key=lambda r: ("low", "medium", "high").index(r["tier"]), reverse=True
         )
 
         return {
-            "total_notes_processed": total_processed,
-            "quality_distribution": quality_distribution,
+            "total_notes_processed": len(fleeting_notes),
+            "quality_distribution": action_counts,
             "recommendations": recommendations,
-            "processing_time": processing_time,
+            "processing_time": time.time() - start_time,
             "quality_threshold": quality_threshold,
             "filtered_count": filtered_count,
         }

--- a/development/src/cli/fleeting_cli.py
+++ b/development/src/cli/fleeting_cli.py
@@ -164,16 +164,16 @@ class FleetingCLI:
     def fleeting_triage(
         self,
         quality_threshold: Optional[float] = 0.7,
-        fast: bool = True,
+        mutate: bool = False,
         output_format: str = "normal",
         export_path: Optional[str] = None,
     ) -> int:
         """
-        Generate AI-powered fleeting notes triage report
+        Generate LLM-powered fleeting notes triage report.
 
         Args:
             quality_threshold: Minimum quality score (0.0-1.0)
-            fast: Use fast mode for better performance
+            mutate: Write triage_recommendation back to frontmatter (default: read-only)
             output_format: 'normal' or 'json'
             export_path: Optional path to export report
 
@@ -193,17 +193,17 @@ class FleetingCLI:
             return 1
 
         logger.info(
-            f"cli=fleeting_cli subcommand=fleeting-triage vault={self.vault_path} format={output_format} quality_threshold={quality_threshold} fast={fast}"
+            f"cli=fleeting_cli subcommand=fleeting-triage vault={self.vault_path} format={output_format} quality_threshold={quality_threshold} mutate={mutate}"
         )
 
         try:
             # Display header
             if not quiet:
-                print("📊 Generating AI-powered fleeting notes triage report...")
+                print("📊 Generating fleeting notes triage report...")
 
             # Generate triage report
             triage_report = self.workflow.generate_fleeting_triage_report(
-                quality_threshold=quality_threshold, fast=fast
+                quality_threshold=quality_threshold, mutate=mutate
             )
 
             # Format and display output

--- a/development/src/cli/fleeting_formatter.py
+++ b/development/src/cli/fleeting_formatter.py
@@ -157,16 +157,19 @@ class FleetingFormatter:
             action_groups[action].append(rec)
 
         for action, recs in action_groups.items():
+            action_lower = action.lower()
             action_emoji = (
                 "✅"
-                if "Promote" in action
-                else "⚠️" if "Enhancement" in action else "🚨"
+                if "promot" in action_lower
+                else "⚠️" if "enhanc" in action_lower else "🚨"
             )
             lines.append(f"   {action_emoji} {action}: {len(recs)} notes")
             for rec in recs[:3]:  # Show top 3 per category
                 note_name = Path(rec["note_path"]).stem
-                quality = rec["quality_score"]
-                lines.append(f"      📄 {note_name} (quality: {quality:.2f})")
+                reasoning = rec.get("reasoning") or ""
+                quality = rec.get("quality_score", 0.0)
+                detail = reasoning[:60] if reasoning else f"quality: {quality:.2f}"
+                lines.append(f"      📄 {note_name} — {detail}")
             if len(recs) > 3:
                 lines.append(f"      ... and {len(recs) - 3} more")
 

--- a/development/src/cli/inneros.py
+++ b/development/src/cli/inneros.py
@@ -10,7 +10,7 @@ Usage:
     inneros --vault /path/to/vault backup
     inneros --vault /path/to/vault backup prune [--keep N] [--dry-run]
     inneros --vault /path/to/vault fleeting health [--format json]
-    inneros --vault /path/to/vault fleeting triage [--quality-threshold 0.8] [--fast]
+    inneros --vault /path/to/vault fleeting triage [--quality-threshold 0.8] [--mutate]
     inneros --vault /path/to/vault review [--preview] [--export] [--format json]
     inneros --vault /path/to/vault review metrics [--format json]
     inneros --vault /path/to/vault inbox [--dry-run] [--format json]
@@ -75,10 +75,15 @@ def _add_fleeting_subcommand(subparsers):
     health.add_argument("--format", choices=["text", "json"], default="text")
     health.add_argument("--export", metavar="FILE", help="Export report to file")
 
-    triage = fleeting_sub.add_parser("triage", help="AI-powered fleeting note triage")
+    triage = fleeting_sub.add_parser(
+        "triage",
+        help="Triage fleeting notes via LLM (read-only by default)",
+    )
     triage.add_argument("--quality-threshold", type=float, default=0.6)
     triage.add_argument(
-        "--fast", action="store_true", help="Skip AI scoring, use heuristics"
+        "--mutate",
+        action="store_true",
+        help="Write triage_recommendation to note frontmatter (default: read-only)",
     )
     triage.add_argument("--format", choices=["text", "json"], default="text")
 
@@ -136,7 +141,7 @@ def _run_fleeting(args) -> int:
         return cli.fleeting_triage(
             output_format=getattr(args, "format", "normal"),
             quality_threshold=getattr(args, "quality_threshold", 0.6),
-            fast=getattr(args, "fast", False),
+            mutate=getattr(args, "mutate", False),
         )
     return cli.fleeting_health(output_format=getattr(args, "format", "normal"))
 

--- a/development/tests/unit/test_fleeting_cli.py
+++ b/development/tests/unit/test_fleeting_cli.py
@@ -60,17 +60,29 @@ class TestDedicatedFleetingCLI:
         assert exit_code == 0
 
     def test_fleeting_triage_command_execution(self):
-        """TEST 3: Verify fleeting-triage command executes successfully."""
+        """TEST 3: Verify fleeting-triage command executes successfully (LLM mocked)."""
+        import json
+        from unittest.mock import patch
         from src.cli.fleeting_cli import FleetingCLI
 
         cli = FleetingCLI(vault_path=str(self.base_dir))
 
-        # Execute fleeting triage command
-        exit_code = cli.fleeting_triage(
-            quality_threshold=0.7, fast=True, output_format="normal"
+        llm_response = json.dumps(
+            {
+                "action": "promote_to_permanent",
+                "reasoning": "Clear, actionable insight.",
+                "confidence": "high",
+            }
         )
 
-        # Should execute without errors
+        with patch("src.ai.lifecycle.OllamaClient") as MockOllama:
+            instance = MockOllama.return_value
+            instance.health_check.return_value = True
+            instance.generate_completion.return_value = llm_response
+            exit_code = cli.fleeting_triage(
+                quality_threshold=0.7, mutate=False, output_format="normal"
+            )
+
         assert exit_code == 0
 
     def test_bug_3_fixed_no_attributeerror(self):

--- a/development/tests/unit/test_inneros_cli.py
+++ b/development/tests/unit/test_inneros_cli.py
@@ -128,11 +128,11 @@ class TestFleetingSubcommand:
         )
         assert args.quality_threshold == pytest.approx(0.8)
 
-    def test_fleeting_triage_has_fast_flag(self):
+    def test_fleeting_triage_has_mutate_flag(self):
         args = self.parser.parse_args(
-            ["--vault", "/tmp", "fleeting", "triage", "--fast"]
+            ["--vault", "/tmp", "fleeting", "triage", "--mutate"]
         )
-        assert args.fast is True
+        assert args.mutate is True
 
 
 # ---------------------------------------------------------------------------

--- a/development/tests/unit/test_llm_triage.py
+++ b/development/tests/unit/test_llm_triage.py
@@ -1,0 +1,249 @@
+"""
+TDD tests for LLM-based fleeting note triage (#114).
+
+RED phase: all tests fail until implementation replaces the word-count heuristic
+with a real Ollama call and wires --mutate through the CLI.
+"""
+
+import json
+import pytest
+import tempfile
+import shutil
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VAULT_NOTE = """\
+---
+type: fleeting
+created: 2026-01-01
+status: inbox
+tags: [ai, test]
+---
+
+# Test Insight
+
+Substantial content about AI automation patterns for small businesses.
+This represents a high-quality capture worth promoting.
+"""
+
+LLM_PROMOTE = json.dumps(
+    {
+        "action": "promote_to_permanent",
+        "reasoning": "Clear, actionable insight with strong strategic fit.",
+        "confidence": "high",
+    }
+)
+
+LLM_ARCHIVE = json.dumps(
+    {
+        "action": "consider_archiving",
+        "reasoning": "Too vague; no concrete next action.",
+        "confidence": "medium",
+    }
+)
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Create minimal vault structure with one fleeting note."""
+    fleeting = tmp_path / "knowledge" / "Fleeting Notes"
+    fleeting.mkdir(parents=True)
+    (fleeting / "test-note.md").write_text(VAULT_NOTE, encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — ReviewTriageCoordinator LLM path
+# ---------------------------------------------------------------------------
+
+
+class TestLlmTriageScoring:
+    """Tests for the LLM scoring path in ReviewTriageCoordinator."""
+
+    def setup_method(self):
+        self.tmp = tempfile.mkdtemp()
+        self.vault = _make_vault(Path(self.tmp))
+        self.knowledge_dir = self.vault / "knowledge"
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp)
+
+    def _make_coordinator(self):
+        from src.ai.lifecycle import ReviewTriageCoordinator
+        from src.ai.batch import WorkflowManager
+
+        wm = WorkflowManager(base_directory=str(self.knowledge_dir))
+        return ReviewTriageCoordinator(
+            base_dir=self.knowledge_dir,
+            workflow_manager=wm,
+        )
+
+    def test_raises_runtime_error_when_ollama_unavailable(self):
+        """Ollama down → RuntimeError with 'Ollama' in message (no silent fallback)."""
+        coordinator = self._make_coordinator()
+
+        with patch("src.ai.lifecycle.OllamaClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health_check.return_value = False
+
+            with pytest.raises(RuntimeError, match="[Oo]llama"):
+                coordinator.generate_fleeting_triage_report(mutate=False)
+
+    def test_raises_value_error_on_malformed_json(self):
+        """LLM returns non-JSON → ValueError with 'malformed' or 'JSON' in message."""
+        coordinator = self._make_coordinator()
+
+        with patch("src.ai.lifecycle.OllamaClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health_check.return_value = True
+            instance.generate_completion.return_value = "not json at all"
+
+            with pytest.raises(
+                (ValueError, RuntimeError), match="[Jj][Ss][Oo][Nn]|malformed|parse"
+            ):
+                coordinator.generate_fleeting_triage_report(mutate=False)
+
+    def test_returns_recommendation_and_reasoning(self):
+        """LLM response → recommendation dict with reasoning field (not just score)."""
+        coordinator = self._make_coordinator()
+
+        with patch("src.ai.lifecycle.OllamaClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health_check.return_value = True
+            instance.generate_completion.return_value = LLM_PROMOTE
+
+            report = coordinator.generate_fleeting_triage_report(mutate=False)
+
+        assert report["total_notes_processed"] >= 1
+        recs = report["recommendations"]
+        assert len(recs) >= 1
+        rec = recs[0]
+        assert "reasoning" in rec, "recommendation must include LLM reasoning"
+        assert "action" in rec
+
+    def test_action_values_match_llm_output(self):
+        """Action label in recommendation comes from LLM JSON, not hard-coded score buckets."""
+        coordinator = self._make_coordinator()
+
+        with patch("src.ai.lifecycle.OllamaClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health_check.return_value = True
+            instance.generate_completion.return_value = LLM_ARCHIVE
+
+            report = coordinator.generate_fleeting_triage_report(mutate=False)
+
+        recs = report["recommendations"]
+        assert any(
+            "archiv" in r["action"].lower() for r in recs
+        ), f"Expected archiving action from LLM, got: {[r['action'] for r in recs]}"
+
+    def test_no_file_writes_without_mutate(self):
+        """Default (mutate=False) → zero filesystem modifications."""
+        note_path = self.knowledge_dir / "Fleeting Notes" / "test-note.md"
+        original_content = note_path.read_text(encoding="utf-8")
+        original_mtime = note_path.stat().st_mtime
+
+        coordinator = self._make_coordinator()
+
+        with patch("src.ai.lifecycle.OllamaClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health_check.return_value = True
+            instance.generate_completion.return_value = LLM_PROMOTE
+
+            coordinator.generate_fleeting_triage_report(mutate=False)
+
+        assert note_path.read_text(encoding="utf-8") == original_content
+        assert note_path.stat().st_mtime == original_mtime
+
+    def test_writes_frontmatter_with_mutate(self):
+        """mutate=True → triage_recommendation written to note frontmatter."""
+        coordinator = self._make_coordinator()
+
+        with patch("src.ai.lifecycle.OllamaClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health_check.return_value = True
+            instance.generate_completion.return_value = LLM_PROMOTE
+
+            coordinator.generate_fleeting_triage_report(mutate=True)
+
+        note_path = self.knowledge_dir / "Fleeting Notes" / "test-note.md"
+        updated = note_path.read_text(encoding="utf-8")
+        assert "triage_recommendation" in updated
+
+
+# ---------------------------------------------------------------------------
+# CLI tests — inneros.py interface
+# ---------------------------------------------------------------------------
+
+
+class TestTriageCLIInterface:
+    """Tests for the inneros fleeting triage CLI interface."""
+
+    def setup_method(self):
+        self.tmp = tempfile.mkdtemp()
+        self.vault = _make_vault(Path(self.tmp))
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp)
+
+    def _run_triage(self, extra_args=None, mock_llm_response=LLM_PROMOTE):
+        """Run triage via FleetingCLI with a mocked Ollama client."""
+        from src.cli.fleeting_cli import FleetingCLI
+
+        cli = FleetingCLI(vault_path=str(self.vault / "knowledge"))
+
+        with patch("src.ai.lifecycle.OllamaClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health_check.return_value = True
+            instance.generate_completion.return_value = mock_llm_response
+
+            kwargs = {"output_format": "normal", "quality_threshold": 0.0}
+            if extra_args:
+                kwargs.update(extra_args)
+            return cli.fleeting_triage(**kwargs)
+
+    def test_triage_accepts_mutate_parameter(self):
+        """fleeting_triage() accepts mutate kwarg without TypeError."""
+        rc = self._run_triage({"mutate": False})
+        assert rc == 0
+
+    def test_triage_default_is_read_only(self):
+        """Default call (no mutate) leaves files unchanged."""
+        note = self.vault / "knowledge" / "Fleeting Notes" / "test-note.md"
+        original = note.read_text(encoding="utf-8")
+
+        self._run_triage()  # no mutate
+
+        assert note.read_text(encoding="utf-8") == original
+
+    def test_fast_flag_removed_from_signature(self):
+        """fleeting_triage() should no longer accept a 'fast' kwarg."""
+        from src.cli.fleeting_cli import FleetingCLI
+        import inspect
+
+        sig = inspect.signature(FleetingCLI.fleeting_triage)
+        assert (
+            "fast" not in sig.parameters
+        ), "'fast' should be removed from fleeting_triage() — use 'mutate' instead"
+
+    def test_inneros_parser_has_mutate_flag(self):
+        """inneros fleeting triage subparser exposes --mutate, not --fast."""
+        from src.cli.inneros import create_parser
+
+        parser = create_parser()
+        # parse the triage subcommand
+        args = parser.parse_args(["--vault", "/tmp/v", "fleeting", "triage"])
+        assert hasattr(args, "mutate"), "--mutate flag missing from triage subparser"
+        assert not hasattr(args, "fast") or True  # --fast removed
+
+    def test_inneros_parser_no_fast_flag(self):
+        """--fast should no longer be a valid triage arg."""
+        from src.cli.inneros import create_parser
+
+        parser = create_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--vault", "/tmp/v", "fleeting", "triage", "--fast"])

--- a/development/tests/unit/test_review_triage_coordinator.py
+++ b/development/tests/unit/test_review_triage_coordinator.py
@@ -268,7 +268,9 @@ class TestFleetingTriageReport:
             assert len(report["recommendations"]) == 1
 
     def test_triage_report_categorizes_by_quality_score(self):
-        """Test triage report categorizes notes by quality thresholds."""
+        """Test triage report categorizes notes by LLM action into quality tiers."""
+        import json
+        from unittest.mock import patch
         from src.ai.review_triage_coordinator import ReviewTriageCoordinator
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -276,37 +278,56 @@ class TestFleetingTriageReport:
             fleeting = vault / "Fleeting Notes"
             fleeting.mkdir()
 
-            # High quality note
             (fleeting / "high.md").write_text(
                 "---\ntitle: High\ntype: fleeting\n---\nContent"
             )
-            # Medium quality note
             (fleeting / "med.md").write_text(
                 "---\ntitle: Med\ntype: fleeting\n---\nContent"
             )
-            # Low quality note
             (fleeting / "low.md").write_text(
                 "---\ntitle: Low\ntype: fleeting\n---\nContent"
             )
 
-            workflow_manager = Mock()
-            # Return different quality scores for each note
-            workflow_manager.process_inbox_note.side_effect = [
-                {"quality_score": 0.8, "ai_tags": [], "metadata": {}},  # High
-                {"quality_score": 0.5, "ai_tags": [], "metadata": {}},  # Medium
-                {"quality_score": 0.2, "ai_tags": [], "metadata": {}},  # Low
+            coordinator = ReviewTriageCoordinator(vault, Mock())
+
+            llm_responses = [
+                json.dumps(
+                    {
+                        "action": "promote_to_permanent",
+                        "reasoning": "good",
+                        "confidence": "high",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "action": "needs_enhancement",
+                        "reasoning": "ok",
+                        "confidence": "medium",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "action": "consider_archiving",
+                        "reasoning": "weak",
+                        "confidence": "low",
+                    }
+                ),
             ]
 
-            coordinator = ReviewTriageCoordinator(vault, workflow_manager)
-
-            report = coordinator.generate_fleeting_triage_report()
+            with patch("src.ai.lifecycle.OllamaClient") as MockOllama:
+                instance = MockOllama.return_value
+                instance.health_check.return_value = True
+                instance.generate_completion.side_effect = llm_responses
+                report = coordinator.generate_fleeting_triage_report()
 
             assert report["quality_distribution"]["high"] == 1
             assert report["quality_distribution"]["medium"] == 1
             assert report["quality_distribution"]["low"] == 1
 
     def test_triage_report_filters_by_quality_threshold(self):
-        """Test triage report can filter notes by minimum quality threshold."""
+        """Test triage report filters notes by minimum quality threshold."""
+        import json
+        from unittest.mock import patch
         from src.ai.review_triage_coordinator import ReviewTriageCoordinator
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -321,22 +342,41 @@ class TestFleetingTriageReport:
                 "---\ntitle: Low\ntype: fleeting\n---\nContent"
             )
 
-            workflow_manager = Mock()
-            workflow_manager.process_inbox_note.side_effect = [
-                {"quality_score": 0.8, "ai_tags": [], "metadata": {}},
-                {"quality_score": 0.3, "ai_tags": [], "metadata": {}},
+            coordinator = ReviewTriageCoordinator(vault, Mock())
+
+            llm_responses = [
+                json.dumps(
+                    {
+                        "action": "promote_to_permanent",
+                        "reasoning": "good",
+                        "confidence": "high",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "action": "consider_archiving",
+                        "reasoning": "weak",
+                        "confidence": "low",
+                    }
+                ),
             ]
 
-            coordinator = ReviewTriageCoordinator(vault, workflow_manager)
+            with patch("src.ai.lifecycle.OllamaClient") as MockOllama:
+                instance = MockOllama.return_value
+                instance.health_check.return_value = True
+                instance.generate_completion.side_effect = llm_responses
+                report = coordinator.generate_fleeting_triage_report(
+                    quality_threshold=0.7
+                )
 
-            report = coordinator.generate_fleeting_triage_report(quality_threshold=0.7)
-
-            # Only high quality note should be in recommendations
+            # Only promote_to_permanent (high tier, score=0.8) passes threshold 0.7
             assert len(report["recommendations"]) == 1
             assert report["filtered_count"] == 1
 
-    def test_triage_report_respects_fast_mode(self):
-        """Test fast mode skips external AI calls for speed."""
+    def test_triage_report_read_only_by_default(self):
+        """Triage without mutate=True must not modify any files."""
+        import json
+        from unittest.mock import patch
         from src.ai.review_triage_coordinator import ReviewTriageCoordinator
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -344,25 +384,25 @@ class TestFleetingTriageReport:
             fleeting = vault / "Fleeting Notes"
             fleeting.mkdir()
 
-            (fleeting / "note.md").write_text(
-                "---\ntitle: Note\ntype: fleeting\n---\nContent"
-            )
+            note = fleeting / "note.md"
+            note.write_text("---\ntitle: Note\ntype: fleeting\n---\nContent")
+            original = note.read_text()
 
-            workflow_manager = Mock()
-            workflow_manager.process_inbox_note.return_value = {
-                "quality_score": 0.7,
-                "ai_tags": [],
-                "metadata": {},
-            }
+            coordinator = ReviewTriageCoordinator(vault, Mock())
 
-            coordinator = ReviewTriageCoordinator(vault, workflow_manager)
+            with patch("src.ai.lifecycle.OllamaClient") as MockOllama:
+                instance = MockOllama.return_value
+                instance.health_check.return_value = True
+                instance.generate_completion.return_value = json.dumps(
+                    {
+                        "action": "promote_to_permanent",
+                        "reasoning": "ok",
+                        "confidence": "high",
+                    }
+                )
+                coordinator.generate_fleeting_triage_report(mutate=False)
 
-            coordinator.generate_fleeting_triage_report(fast=True)
-
-            # Verify process_inbox_note was called with fast=True
-            workflow_manager.process_inbox_note.assert_called()
-            call_kwargs = workflow_manager.process_inbox_note.call_args[1]
-            assert call_kwargs.get("fast") is True
+            assert note.read_text() == original
 
     def test_triage_report_includes_processing_time(self):
         """Test triage report includes total processing time."""


### PR DESCRIPTION
Re-open targeting main (previous base feat/122-repo-isolation now merged).

## Summary

- Replaces the word-count heuristic in `ReviewTriageCoordinator.generate_fleeting_triage_report()` with a real Ollama LLM call
- **No silent fallback** — Ollama unavailable raises `RuntimeError`; malformed JSON raises `ValueError`
- **Read-only by default** — `--mutate` flag required to write `triage_recommendation` to frontmatter
- Swapped `--fast` → `--mutate` in `inneros fleeting triage` subcommand
- 11 new unit tests in `test_llm_triage.py`; updated 5 existing tests

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)